### PR TITLE
Fixed Vte versions problem

### DIFF
--- a/activity.py
+++ b/activity.py
@@ -20,9 +20,11 @@
 import logging
 from gettext import gettext as _
 
+from gi import require_version
 from gi.repository import Gtk
 from gi.repository import Gdk
 from gi.repository import Pango
+require_version('Vte', '2.90')
 from gi.repository import Vte
 from gi.repository import GLib
 

--- a/pippy_app.py
+++ b/pippy_app.py
@@ -40,10 +40,12 @@ from gettext import gettext as _
 import dbus
 from dbus.mainloop.glib import DBusGMainLoop
 
+from gi import require_version
 from gi.repository import Gtk
 from gi.repository import Gdk
 from gi.repository import GLib
 from gi.repository import Pango
+require_version('Vte', '2.90')
 from gi.repository import Vte
 from gi.repository import GObject
 


### PR DESCRIPTION
* Forcing Pippy to use Vte 2.90 avoid problems with computers with newer Vte libraries