### PR TITLE
use latest collabwrapper.py

### DIFF
--- a/collabwrapper.py
+++ b/collabwrapper.py
@@ -178,6 +178,7 @@ class CollabWrapper(GObject.GObject):
                 self._alert(_('Joining activity...'),
                             _('Please wait for the connection...'))
         else:
+            self._leader = True
             if not self.activity.metadata or self.activity.metadata.get(
                     'share-scope', SCOPE_PRIVATE) == \
                     SCOPE_PRIVATE:
@@ -203,8 +204,6 @@ class CollabWrapper(GObject.GObject):
         self.shared_activity = self.activity.shared_activity
         self._setup_text_channel()
         self._listen_for_channels()
-
-        self._leader = True
         _logger.debug('I am sharing...')
 
     def __joined_cb(self, sender):
@@ -364,6 +363,14 @@ class CollabWrapper(GObject.GObject):
         '''
         return CLIENT + '.' + self.activity.get_bundle_id()
 
+    @GObject.property
+    def leader(self):
+        '''
+        Boolean of if this client is the leader in this activity.  The
+        way the leader is decided may change, however there should only
+        ever be 1 leader for an activity.
+        '''
+        return self._leader
 
 FT_STATE_NONE = 0
 FT_STATE_PENDING = 1
@@ -657,8 +664,7 @@ class OutgoingFileTransfer(_BaseOutgoingTransfer):
         self._create_channel(file_size)
 
     def _get_input_stream(self):
-        logging.debug('opening %s for reading', self._file_name)
-        input_stream = Gio.File.new_for_path(self._file_name).read(None)
+        input_stream = Gio.File.new_for_path(self._path).read(None)
 
 
 class OutgoingBlobTransfer(_BaseOutgoingTransfer):


### PR DESCRIPTION
Fixes failure to start in Pippy-70, tested on Ubuntu 15.10, caused by
my mixing versions of collabwrapper sources.

```
Traceback (most recent call last):
  File "/usr/bin/sugar-activity", line 169, in <module>
    main()
  File "/usr/bin/sugar-activity", line 164, in main
    instance = create_activity_instance(activity_constructor, activity_handle)
  File "/usr/bin/sugar-activity", line 42, in create_activity_instance
    activity = constructor(handle)
  File "/usr/share/sugar/activities/Pippy.activity/pippy_app.py", line 160, in __init__
    self.set_canvas(self.initialize_display())
  File "/usr/share/sugar/activities/Pippy.activity/pippy_app.py", line 387, in initialize_display
    self._source_tabs.add_tab()  # New instance, ergo empty tab
  File "/usr/share/sugar/activities/Pippy.activity/notebook.py", line 209, in add_tab
    buffer_text, editor_id, self._collab)
  File "/usr/share/sugar/activities/Pippy.activity/notebook.py", line 151, in __init__
    text_buffer, editor_id, collab)
  File "/usr/share/sugar/activities/Pippy.activity/texteditor.py", line 80, in __init__
    if not self._collab.props.leader:
AttributeError: 'gi._gobject.GProps' object has no attribute 'leader'
```