### PR TITLE
Port to GtkSource 4

### DIFF
--- a/notebook.py
+++ b/notebook.py
@@ -26,7 +26,7 @@ from gi.repository import Gtk
 from gi.repository import Gdk
 from gi.repository import GObject
 from gi.repository import Pango
-require_version('GtkSource', '3.0')
+require_version('GtkSource', '4')
 from gi.repository import GtkSource
 from gettext import gettext as _
 


### PR DESCRIPTION
GtkSourceView 3 is deprecated and unmaintained a long time ago. It seems that changing the version number is enough, it works fine.